### PR TITLE
Fix running VS code

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <style type="text/css">
-    body { 
+    body {
         padding: 0 10px 5px;
         font-family: Helvetica, Arial, sans-serif;
         font-size: 16px;
         overflow: hidden;
     }
-    input { 
+    input {
         min-width: 150px;
         padding: 3px;
         display: inline-block;
@@ -53,7 +53,7 @@
             <select value="sublime" id="editor" class="editor">
                 <option value="sublime">Sublime</option>
                 <option value="atom">Atom</option>
-                <option value="vscode">VScode</option>
+                <option value="code">VScode</option>
                 <option value="webstorm">Webstorm</option>
                 <option value="textmate">Textmate</option>
                 <option value="vim">Vim</option>

--- a/src/server.js
+++ b/src/server.js
@@ -2,8 +2,11 @@
 
 const express = require('express');
 const openInEditor = require('open-in-editor');
+const fs = require('fs');
 const app = express();
 let editor = 'sublime';
+
+const vsCodeCmd = '/usr/local/bin/code';
 
 app.use(function(req, res, next) {
     res.header('Access-Control-Allow-Origin', '*');
@@ -16,10 +19,16 @@ app.use(function(req, res, next) {
 
 app.get('/openeditor', function(req, res) {
     let { options = '' } = req.query;
-    var editorFunc = openInEditor.configure(
-        {
-            editor
-        },
+
+    const params = { editor };
+
+    // Running VS code inside electron on Mac does not work if path contains spaces. But works well with command line shortcut
+    if (editor === 'code' && fs.existsSync(vsCodeCmd)) {
+        params.cmd = vsCodeCmd;
+    }
+
+    const editorFunc = openInEditor.configure(
+        params,
         () => {}
     );
     editorFunc.open(options);


### PR DESCRIPTION
There were two issues:
- wrong option for `open-in-editor` - there should be `code` instead of `vscode`
- strange error when using default path to VS code:
<img width="1665" alt="screen shot 2017-11-23 at 19 28 12" src="https://user-images.githubusercontent.com/5306643/33182314-8f5e5722-d084-11e7-882c-c0ccf5efea3c.png">

I didn't find true reason why running VS code fails. But found that it works correctly when specifying VS code via `code` command. 

So I decided to hack it via custom editor path redefinition.

Note: This issue seems to be only reproduced in Electron. I couldn't reproduce this issue in Node.js (at least in Node v8)