### PR TITLE
Refactor renderer to use preload bridge

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -63,29 +63,28 @@
         <button class="close-btn" type="button">Close</button>
     </form>
 <script>
-    const electron = require('electron');
-    const remote = electron.remote;
     const port = document.querySelector('.port');
     const editor = document.querySelector('.editor');
     const closeBtn = document.querySelector('.close-btn');
     const versionLabel = document.querySelector('.version');
-    const config = remote.getGlobal('config');
-    const restartServer = remote.getGlobal('restartServer');
-    const pkg = require('../package.json');
-    versionLabel.innerText = pkg.version;
+    const { getConfig, setConfig, restartServer, version } = window.electronAPI;
+    versionLabel.innerText = version;
 
     function onSubmit(event) {
         event ? event.preventDefault() : null;
-        config.set({
+        setConfig({
             port: port.value,
             editor: editor.value
         });
         event ? restartServer(true) : null;
     }
 
-    port.value = config.get('port');
-    editor.value = config.get('editor');
-    closeBtn.addEventListener('click', restartServer);
+    getConfig().then(cfg => {
+        port.value = cfg.port;
+        editor.value = cfg.editor;
+    });
+
+    closeBtn.addEventListener('click', () => restartServer());
     document.querySelector('form').addEventListener('submit', onSubmit);
 </script>
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,10 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const pkg = require('../package.json');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+    getConfig: () => ipcRenderer.invoke('get-config'),
+    setConfig: (settings) => ipcRenderer.invoke('set-config', settings),
+    restartServer: (forceRestart) =>
+        ipcRenderer.invoke('restart-server', forceRestart),
+    version: pkg.version
+});


### PR DESCRIPTION
## Summary
- replace deprecated `remote` usage with secure preload context bridge
- expose config, restart, and version to renderer via IPC
- update renderer script to use preload API

## Testing
- `npm test` *(fails: ESLint 9 requires eslint.config.js; package installation blocked by macOS-specific dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f2e77d48328b724f02814b650b8